### PR TITLE
feat: added Rescuable

### DIFF
--- a/src/contracts/utils/Rescuable.sol
+++ b/src/contracts/utils/Rescuable.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.8;
+
+import {IERC20} from '../oz-common/interfaces/IERC20.sol';
+import {SafeERC20} from '../oz-common/SafeERC20.sol';
+
+abstract contract Rescuable {
+  using SafeERC20 for IERC20;
+
+  event ERC20Rescued(
+    address indexed caller,
+    address indexed token,
+    address indexed to,
+    uint256 amount
+  );
+
+  event NativeTokensRescued(address indexed caller, address indexed to, uint256 amount);
+
+  modifier onlyRescueGuardian() {
+    require(msg.sender == whoCanRescue(), 'ONLY_RESCUE_GUARDIAN');
+    _;
+  }
+
+  function emergencyTokenTransfer(
+    address erc20Token,
+    address to,
+    uint256 amount
+  ) external onlyRescueGuardian {
+    IERC20(erc20Token).safeTransfer(to, amount);
+
+    emit ERC20Rescued(msg.sender, erc20Token, to, amount);
+  }
+
+  function emergencyEtherTransfer(address to, uint256 amount) external onlyRescueGuardian {
+    (bool success, ) = to.call{value: amount}(new bytes(0));
+    require(success, 'ETH_TRANSFER_FAIL');
+
+    emit NativeTokensRescued(msg.sender, to, amount);
+  }
+
+  function whoCanRescue() public view virtual returns (address);
+}


### PR DESCRIPTION
Quite commonly we introduce "rescue" functions for both ERC20 and ETH (or other native token) mixed with the business logic of other systems, which results in a polluted mix.

This abstracts it with the following design decisions:
- It is not up to `Rescuable` to understand if actually the contract can receive ETH, it just assumes that is possible.
- The access control on who can rescue boils down to the system using the abstract contract. Opinionated decision to require the implementation of a view function returning the address of who can rescue, instead of forcing requires, as there should always be access control (because the `to` to send tokens/ETH is "open").