### PR TITLE
fix: linea custom patch

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,8 +4,11 @@ tests = 'tests'
 script = 'script'
 out = 'out'
 libs = ['lib']
-evm_version = 'shanghai'
+evm_version = 'london'
 remappings = []
+optimizer_runs = 200
+solc = '0.8.20'
+bytecode_hash = 'none'
 
 [profile.zksync]
 src = 'zksync/src'

--- a/verify.json
+++ b/verify.json
@@ -1,0 +1,6 @@
+{
+  "transactions": [
+    { "hash": "0xf2ed92eb3cb33de603eabe68e31137b42484ccddd63d47e9b6195bc650283e3d" }
+  ],
+  "chain": 59144
+}


### PR DESCRIPTION
npx catapulta-verify@1.2.2-8d32ccd9a1da7eff0fe5678627996d3572d3e517.0 -b verify.json

put `ETHERSCAN_API_KEY` in your global env (not sure if must be a mainnet etherscan key or not, i'm using one at least)