### PR TITLE
chore: lock submodule release branch openzeppelin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
+  branch = release-v5.0

--- a/foundry.toml
+++ b/foundry.toml
@@ -18,7 +18,7 @@ evm_version = 'cancun'
 [profile.zksync.zksync]
 fallback_oz = true
 mode = "3"
-zksolc = "1.4.1"
+zksolc = "1.5.4"
 
 # See more config options https://github.com/gakonst/foundry/tree/master/config
 [rpc_endpoints]


### PR DESCRIPTION
- Locks the openzeppelin-upgradable-contracts submodule to the specific release branch: `v5.0`
- Updates zksolc compiler config to `v1.5.4`